### PR TITLE
Install libpulse0

### DIFF
--- a/sdk/tools/Dockerfile
+++ b/sdk/tools/Dockerfile
@@ -11,7 +11,7 @@ RUN cd /opt \
     && rm android-sdk-tools.zip
 
 RUN apt-get update \
-    && apt-get install -y sudo software-properties-common build-essential ruby-full lib32stdc++6 --no-install-recommends \
+    && apt-get install -y sudo software-properties-common build-essential ruby-full lib32stdc++6 libpulse0 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install fastlane -NV


### PR DESCRIPTION
Apparently libpulse0 is required to start the android emulator API Level 29 even if `-no-audio` is used