### PR TITLE
Install libglu1-mesa

### DIFF
--- a/sdk/tools/Dockerfile
+++ b/sdk/tools/Dockerfile
@@ -11,7 +11,7 @@ RUN cd /opt \
     && rm android-sdk-tools.zip
 
 RUN apt-get update \
-    && apt-get install -y sudo software-properties-common build-essential ruby-full lib32stdc++6 libpulse0 --no-install-recommends \
+    && apt-get install -y sudo software-properties-common build-essential ruby-full lib32stdc++6 libpulse0 libglu1-mesa --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN gem install fastlane -NV


### PR DESCRIPTION
Apparently `libglu1-mesa` is required to start the android emulator API Level 29 even if argument `-no-window` is used