### PR TITLE
Arm Image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,15 +7,15 @@ docker_builder:
     - docker buildx use multibuilder
     - docker buildx inspect --bootstrap
   build_tools_script: |
-    docker buildx build --platform linux/amd64,linux/arm64 --load \
+    docker buildx build --platform linux/amd64,linux/arm64 \
       --tag ghcr.io/cirruslabs/android-sdk:tools \
       sdk/tools
   build_sdk_script: |
-    docker buildx build --platform linux/amd64,linux/arm64 --load \
+    docker buildx build --platform linux/amd64,linux/arm64 \
       --tag ghcr.io/cirruslabs/android-sdk:34 \
       sdk/34
   build_ndk_script: |
-    docker buildx build --platform linux/amd64,linux/arm64 --load \
+    docker buildx build --platform linux/amd64,linux/arm64 \
       --tag ghcr.io/cirruslabs/android-sdk:34-ndk \
       sdk/34-ndk
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,15 +7,15 @@ docker_builder:
     - docker buildx use multibuilder
     - docker buildx inspect --bootstrap
   build_tools_script: |
-    docker buildx build --load \
+    docker buildx build --platform linux/amd64,linux/arm64 --load \
       --tag ghcr.io/cirruslabs/android-sdk:tools \
       sdk/tools
   build_sdk_script: |
-    docker buildx build --load \
+    docker buildx build --platform linux/amd64,linux/arm64 --load \
       --tag ghcr.io/cirruslabs/android-sdk:34 \
       sdk/34
   build_ndk_script: |
-    docker buildx build --load \
+    docker buildx build --platform linux/amd64,linux/arm64 --load \
       --tag ghcr.io/cirruslabs/android-sdk:34-ndk \
       sdk/34-ndk
 
@@ -32,14 +32,14 @@ docker_builder:
     - docker buildx use multibuilder
     - docker buildx inspect --bootstrap
   build_tools_script: |
-    docker buildx build --push \
+    docker buildx build --platform linux/amd64,linux/arm64 --push \
       --tag ghcr.io/cirruslabs/android-sdk:tools \
       sdk/tools
   build_sdk_script: |
-    docker buildx build --push \
+    docker buildx build --platform linux/amd64,linux/arm64 --push \
       --tag ghcr.io/cirruslabs/android-sdk:34 \
       sdk/34
   build_ndk_script: |
-    docker buildx build --push \
+    docker buildx build --platform linux/amd64,linux/arm64 --push \
       --tag ghcr.io/cirruslabs/android-sdk:34-ndk \
       sdk/34-ndk

--- a/sdk/tools/Dockerfile
+++ b/sdk/tools/Dockerfile
@@ -43,4 +43,4 @@ RUN set -o xtrace \
     && git config --global user.email "support@cirruslabs.org" \
     && git config --global user.name "Cirrus CI"
 
-RUN if [[ $(uname -m) == "x86_64" ]] ; then sdkmanager emulator ; fi
+RUN sdkmanager emulator

--- a/sdk/tools/Dockerfile
+++ b/sdk/tools/Dockerfile
@@ -43,4 +43,4 @@ RUN set -o xtrace \
     && git config --global user.email "support@cirruslabs.org" \
     && git config --global user.name "Cirrus CI"
 
-RUN sdkmanager emulator
+RUN if [[ $(uname -m) == "x86_64" ]] ; then sdkmanager emulator ; fi


### PR DESCRIPTION
Fixes #60 but still [`sdkmanager emulator` doesn't work](https://github.com/cirruslabs/docker-images-android/blob/657cd7da16ff227d277a28e4466aac7a1ec0906a/sdk/tools/Dockerfile#L46).