### PR TITLE
Add lftp, xxd, sqlite3

### DIFF
--- a/sdk/tools/Dockerfile
+++ b/sdk/tools/Dockerfile
@@ -23,6 +23,9 @@ RUN set -o xtrace \
     && apt-get install -y sudo wget zip unzip git openssh-client curl bc software-properties-common build-essential ruby-full ruby-bundler libstdc++6 libpulse0 libglu1-mesa locales lcov libsqlite3-dev --no-install-recommends \
     # for x86 emulators
     && apt-get install -y libxtst6 libnss3-dev libnspr4 libxss1 libasound2t64 libatk-bridge2.0-0 libgtk-3-0 libgdk-pixbuf2.0-0 \
+    && apt-get install -y -qq xxd \
+    && apt-get install -y lftp \
+    && apt-get install -qq -y sqlite3 libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/* \
     && sh -c 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen' \
     && locale-gen \


### PR DESCRIPTION
I have add these libraries because it's crucial in ci pipelines for flutter developers, sqlite3 is used in offline first approach apps in testing phase to ensure database queries are runing, xxd use to write jsk file, and lftp used to upload final apk in specific server